### PR TITLE
Standardize Claude GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -93,13 +93,18 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
         run: |
-          # If all three secrets are set, write a private creds file the
-          # helper sources at call time. `printf %q` shell-quotes values
-          # so secrets with special chars round-trip safely. If any
-          # secret is empty (repo hasn't opted into image uploads), skip
-          # the creds file entirely; the helper will see no file and
-          # exit with a clear "not configured" message.
+          # If all three required secrets are set, write a private creds file
+          # the helper sources at call time. `printf %q` shell-quotes values
+          # so secrets with special chars round-trip safely. If any required
+          # secret is empty (repo hasn't opted into image uploads), skip the
+          # creds file entirely; the helper will see no file and exit with a
+          # clear "not configured" message.
+          # R2_BUCKET and R2_PUBLIC_URL are optional; they default to the
+          # canonical values (img / https://img.chriscalo.com) when unset,
+          # so existing repos don't need new secrets.
           creds_file="$RUNNER_TEMP/.upload-image-creds"
           if [ -n "${R2_ACCOUNT_ID:-}" ] \
              && [ -n "${R2_ACCESS_KEY_ID:-}" ] \
@@ -110,6 +115,8 @@ jobs:
               printf 'AWS_SECRET_ACCESS_KEY=%q\n' "$R2_SECRET_ACCESS_KEY"
               printf 'AWS_DEFAULT_REGION=auto\n'
               printf 'R2_ACCOUNT_ID=%q\n'         "$R2_ACCOUNT_ID"
+              printf 'R2_BUCKET=%q\n'             "${R2_BUCKET:-img}"
+              printf 'R2_PUBLIC_URL=%q\n'         "${R2_PUBLIC_URL:-https://img.chriscalo.com}"
             } > "$creds_file"
             chmod 600 "$creds_file"
           fi
@@ -169,11 +176,11 @@ jobs:
             *)        content_type=application/octet-stream ;;
           esac
 
-          aws s3 cp "$local_path" "s3://img/$remote_key" \
+          aws s3 cp "$local_path" "s3://${R2_BUCKET}/$remote_key" \
             --endpoint-url "https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com" \
             --content-type "$content_type" \
             >/dev/null
-          echo "https://img.chriscalo.com/$remote_key"
+          echo "${R2_PUBLIC_URL%/}/$remote_key"
           HELPER_EOF
           chmod +x "$RUNNER_TEMP/bin/upload-image"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Adds (or replaces) `.github/workflows/claude.yaml` with the
canonical workflow from
[chriscalo/dev-skills](https://github.com/chriscalo/dev-skills/blob/main/skills/github/claude-action-workflow.yaml).

**Tool policy**: `--allowedTools "Read,Grep,Glob,Edit,Write,Skill,Task,Agent,Bash(*),WebFetch,WebSearch"`
with a targeted `--disallowedTools` list. See
[claude-action.md "Tool policy"](https://github.com/chriscalo/dev-skills/blob/main/skills/github/claude-action.md#tool-policy)
for rationale.

Future drift can be detected via
`sync-claude-action.sh audit OWNER/REPO`.